### PR TITLE
Wrap gap in a list item tag

### DIFF
--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -4,5 +4,6 @@
 -#    total_pages:   total number of pages
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
-%span.page.gap
-  = raw(t 'views.pagination.truncate')
+%li
+  %span.page.gap
+    = raw(t 'views.pagination.truncate')


### PR DESCRIPTION
Ensures that it remains as part of the list so that the nav bar is one
row
